### PR TITLE
increased timeout for forward_request

### DIFF
--- a/backend/api-gateway/gateway.py
+++ b/backend/api-gateway/gateway.py
@@ -78,7 +78,8 @@ app.add_middleware(BaseHTTPMiddleware, dispatch=verify_jwt)
 
 # Proxy function
 async def forward_request(service_url: str, path: str, request: Request) -> Response:
-    async with httpx.AsyncClient() as client:
+    timeout = httpx.Timeout(360.0, connect=10.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
         body = await request.body()
         headers = dict(request.headers)
         print("A")


### PR DESCRIPTION
Added timeout = httpx.Timeout(360.0, connect=10.0) - 360 seconds (6 minutes) for the request, 10 seconds for initial connection to forward_request function. This allowed my endpoints to send a successful response when testing using postman.